### PR TITLE
add stryker mutation tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -314,6 +314,234 @@
         }
       }
     },
+    "@stryker-mutator/api": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-1.0.3.tgz",
+      "integrity": "sha512-JMDfhnjQ3HGYeSnwBv6/5wEs8d58b1YOhGKty6rKcpI+Ngi/n67ll9L4qwbIjoxmO5S/0nc9NtHwyz49FwJYLA==",
+      "dev": true,
+      "requires": {
+        "tslib": "~1.9.3"
+      }
+    },
+    "@stryker-mutator/core": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-1.0.3.tgz",
+      "integrity": "sha512-upmN47Tw2PKK05GjucGMj9m2CUbUXNTNQw6cLOfHjduN+8HMLWH7vab0TdWcWlOklqSmWVksQLluu2PmaM+4bw==",
+      "dev": true,
+      "requires": {
+        "@stryker-mutator/api": "^1.0.3",
+        "@stryker-mutator/util": "^1.0.3",
+        "chalk": "~2.4.1",
+        "commander": "~2.19.0",
+        "get-port": "~4.1.0",
+        "glob": "~7.1.2",
+        "inquirer": "~6.2.0",
+        "istanbul-lib-instrument": "~3.1.0",
+        "lodash": "~4.17.4",
+        "log4js": "~4.0.2",
+        "mkdirp": "~0.5.1",
+        "prettier": "~1.16.1",
+        "progress": "~2.0.0",
+        "rimraf": "~2.6.1",
+        "rxjs": "~6.3.0",
+        "source-map": "~0.6.1",
+        "surrial": "~1.0.0",
+        "tree-kill": "~1.2.0",
+        "tslib": "~1.9.3",
+        "typed-inject": "~1.0.0",
+        "typed-rest-client": "~1.1.2"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+          "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.11",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.4.0",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+              "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
+    "@stryker-mutator/javascript-mutator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/javascript-mutator/-/javascript-mutator-1.0.3.tgz",
+      "integrity": "sha512-J5ZijSKVDKh+FUtqKjPYwPwKSRG5924YRjlyZcIfMkWj9sYmUEhM6T27SQ537EAIzVMtCZirc1SE7N6Dii0dwg==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "~7.3.2",
+        "@babel/parser": "~7.3.1",
+        "@babel/traverse": "~7.3.4",
+        "@stryker-mutator/api": "^1.0.3",
+        "lodash": "~4.17.4",
+        "tslib": "~1.9.3"
+      },
+      "dependencies": {
+        "@babel/traverse": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+          "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.3.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.3.4",
+            "@babel/types": "^7.3.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          },
+          "dependencies": {
+            "@babel/generator": {
+              "version": "7.3.4",
+              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+              "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.3.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.3.4",
+              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+              "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@stryker-mutator/jest-runner": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-1.0.3.tgz",
+      "integrity": "sha512-a6Moys+InHdimdWdc+VM8zpbXRynaZf41G72fswsf1E5ho40A85Yw0WrncpXB2mTgpxBHcg3MBcuohQAR+80sQ==",
+      "dev": true,
+      "requires": {
+        "@stryker-mutator/api": "^1.0.3",
+        "semver": "~5.6.0"
+      }
+    },
+    "@stryker-mutator/util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-1.0.3.tgz",
+      "integrity": "sha512-ZsPxAvud/1OsgA3FD9Ia8lDEVzzrm2MvQuV23Q/6T5Rt1T1jX+lRGI73/K66iLykvqQyI+B7MAgRk3tDuep7Eg==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -1024,6 +1252,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-types": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.3.0.tgz",
@@ -1356,6 +1590,12 @@
           }
         }
       }
+    },
+    "date-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
+      "integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA==",
+      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -2203,6 +2443,12 @@
         "locate-path": "^3.0.0"
       }
     },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
@@ -2278,6 +2524,17 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs-minipass": {
       "version": "1.2.5",
@@ -2865,6 +3122,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-port": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.1.0.tgz",
+      "integrity": "sha512-4/fqAYrzrzOiqDrdeZRKXGdTGgbkfTEumGlNQPeP6Jy8w0PzN9mzeNQ3XgHaTNie8pQ3hOUkrwlZt2Fzk5H9mA==",
       "dev": true
     },
     "get-stream": {
@@ -4090,6 +4353,15 @@
         }
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4274,6 +4546,30 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "log4js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.0.2.tgz",
+      "integrity": "sha512-KE7HjiieVDPPdveA3bJZSuu0n8chMkFl8mIoisBFxwEJ9FmXe4YzNuiqSwYUiR1K8q8/5/8Yd6AClENY1RA9ww==",
+      "dev": true,
+      "requires": {
+        "date-format": "^2.0.0",
+        "debug": "^3.1.0",
+        "flatted": "^2.0.0",
+        "rfdc": "^1.1.2",
+        "streamroller": "^1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -5098,6 +5394,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
@@ -5130,6 +5432,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prompts": {
@@ -5418,6 +5726,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
+      "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -5447,6 +5761,15 @@
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -5948,6 +6271,30 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "streamroller": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.3.tgz",
+      "integrity": "sha512-P7z9NwP51EltdZ81otaGAN3ob+/F88USJE546joNq7bqRNTe6jc74fTBDyynxP4qpIfKlt/CesEYicuMzI0yJg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "date-format": "^2.0.0",
+        "debug": "^3.1.0",
+        "fs-extra": "^7.0.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -6075,6 +6422,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "surrial": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/surrial/-/surrial-1.0.0.tgz",
+      "integrity": "sha512-dkvhz3QvgraMeFWI9V+BinpNCNoaSNxKcxb0umRpkWeFlZ0WSbIfeTm9YtLA6a4kv/Q2pOMQOtMlcv/b5h6qpg==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -6278,10 +6631,28 @@
       "integrity": "sha512-93WeyHNuRggPEsfCe+yHxCgM2s6H3Q8Wmlt6b6ObJL8qc7eZlRaFjQxwTrB+zbvGtlDRnAkMoYYo3+2uH/fEwA==",
       "dev": true
     },
+    "tree-kill": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "dev": true
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
       "dev": true
     },
     "tunnel-agent": {
@@ -6316,6 +6687,22 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
+      }
+    },
+    "typed-inject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-1.0.0.tgz",
+      "integrity": "sha512-u1ZR7Zvu0NIIZjiLg8RSp4oOoSs8wUnsn8mQ3Pnl8fHmCNkA7Y/aOKTR/Stp4R9/bazwphSktuOEMP++DdlAKQ==",
+      "dev": true
+    },
+    "typed-rest-client": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.1.2.tgz",
+      "integrity": "sha512-ToUH2PwqagO3L2vcLHJc8uvJlNeioxDkHPeN5WGJLaN6VOh01GvYoo0WwPk1sHSJfrVjxAPgtrRuZQiYjwFEaw==",
+      "dev": true,
+      "requires": {
+        "tunnel": "0.0.4",
+        "underscore": "1.8.3"
       }
     },
     "typedarray": {
@@ -6400,6 +6787,12 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unixify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "generate:key-pair": "node util/generateKeyPair.js",
     "test": "jest",
     "test:pact": "NODE_ENV=pact jest --testRegex \"/*(.test.pact.js)\" --runInBand --setupFiles ./tests/pactSetup.js --setupFilesAfterEnv ./tests/pactTestWrapper.js",
+    "test:mutate": "npx stryker run",
     "test:watch": "jest --watch"
   },
   "repository": {
@@ -25,6 +26,9 @@
   "dependencies": {},
   "devDependencies": {
     "@pact-foundation/pact": "^7.2.0",
+    "@stryker-mutator/core": "^1.0.3",
+    "@stryker-mutator/javascript-mutator": "^1.0.3",
+    "@stryker-mutator/jest-runner": "^1.0.3",
     "axios": "^0.18.0",
     "jest": "^24.1.0",
     "jsverify": "^0.8.4"

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,0 +1,15 @@
+module.exports = (config) => {
+  config.set({
+    clearTextReporter: { logTests: true },
+    files: ['*.js','id_rsa','id_rsa.pub'],
+  	mutate: ["auth.js","signature.js"],
+    mutator: "javascript",
+    packageManager: "npm",
+    reporters: ["clear-text", "progress"],
+    testRunner: "jest",
+    thresholds: { 
+    	high: 80, 
+    	low: 60, 
+    	break: 50 }
+  });
+};


### PR DESCRIPTION
stryker mutates your test code and then runs your unit tests against those "mutants" to see what sort of shenanigans your unit tests catch. 

## reporting
it reports back on the number of tests run, the number of tests "killed" by your unit tests, the number survived and the number that errored. there are also metrics for tests that time out or has no coverage, but our tests don't seem to trigger that. it then calculates a percent "score" that seems to roughly correlate to `#killed+#errored/#totalTestsRun`.

i turned on reporting on each mutant that survived so we can see what's worthwhile to put a test in to fix. 

<img width="644" alt="screen shot 2019-03-01 at 9 43 48 pm" src="https://user-images.githubusercontent.com/2008796/53676061-7692a500-3c6b-11e9-8cf8-cecce4d46dfb.png">

## reporting thresholds
i've held on to the defaults for now, 80% for good enough; 60% for passable and added a test failure for 50% because if half of these mutants aren't being caught by our tests, we need to consider whether are tests are covering enough to handle any stupid decisions we make going forward. 